### PR TITLE
Fix frame problems with empty namespaces

### DIFF
--- a/kobuki_description/launch/kobuki_description.launch.py
+++ b/kobuki_description/launch/kobuki_description.launch.py
@@ -21,9 +21,9 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 import launch_ros.descriptions
 from launch.substitutions import Command
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration
+from launch.actions import DeclareLaunchArgument, OpaqueFunction, GroupAction
+from launch.conditions import IfCondition, UnlessCondition
+from launch.substitutions import LaunchConfiguration, EqualsSubstitution
 
 
 def modify_yaml_with_namespace(original_yaml_path, namespace):
@@ -141,23 +141,47 @@ def generate_launch_description():
         description='Namespace to apply to the nodes'
     )
 
-    robot_model = Node(
-        package='robot_state_publisher',
-        executable='robot_state_publisher',
-        namespace=LaunchConfiguration('namespace'),
-        parameters=[{
-            'robot_description': launch_ros.descriptions.ParameterValue(
-                Command([
-                    'xacro ', LaunchConfiguration('description_file'),
-                    ' lidar:=', LaunchConfiguration('lidar'),
-                    ' camera:=', LaunchConfiguration('camera'),
-                    ' structure:=', LaunchConfiguration('structure'),
-                    ' namespace:=', LaunchConfiguration('namespace'),
-                    ' gazebo:=', LaunchConfiguration('gazebo')
-                ]), value_type=str),
-            'use_sim_time': LaunchConfiguration('use_sim_time')
-        }],
-    )
+    # Check if the namespace is set and generate the corresponding URDF.
+    # If a namespace is used, a trailing '/' is added.
+    # Otherwise the node is launched without namespace
+    is_empty_namespace = EqualsSubstitution(LaunchConfiguration('namespace'), '')
+    robot_model = GroupAction([
+        Node(
+            condition=IfCondition(is_empty_namespace),
+            package='robot_state_publisher',
+            executable='robot_state_publisher',
+            parameters=[{
+                'robot_description': launch_ros.descriptions.ParameterValue(
+                    Command([
+                        'xacro ', LaunchConfiguration('description_file'),
+                        ' lidar:=', LaunchConfiguration('lidar'),
+                        ' camera:=', LaunchConfiguration('camera'),
+                        ' structure:=', LaunchConfiguration('structure'),
+                        ' gazebo:=', LaunchConfiguration('gazebo')
+                    ]), value_type=str),
+                'use_sim_time': LaunchConfiguration('use_sim_time')
+            }],
+        ),
+        Node(
+            condition=UnlessCondition(is_empty_namespace),
+            package='robot_state_publisher',
+            executable='robot_state_publisher',
+            namespace=LaunchConfiguration('namespace'),
+            parameters=[{
+                'robot_description': launch_ros.descriptions.ParameterValue(
+                    Command([
+                        'xacro ', LaunchConfiguration('description_file'),
+                        ' lidar:=', LaunchConfiguration('lidar'),
+                        ' camera:=', LaunchConfiguration('camera'),
+                        ' structure:=', LaunchConfiguration('structure'),
+                        # Must append the trailing slash when a namespace is active
+                        ' namespace:=', LaunchConfiguration('namespace'), '/',
+                        ' gazebo:=', LaunchConfiguration('gazebo')
+                    ]), value_type=str),
+                'use_sim_time': LaunchConfiguration('use_sim_time')
+            }],
+        ),
+    ])
 
     # TF Tree
     joint_state_publisher_node = Node(

--- a/kobuki_description/launch/kobuki_description.launch.py
+++ b/kobuki_description/launch/kobuki_description.launch.py
@@ -19,7 +19,7 @@ import tempfile
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
-import launch_ros.descriptions
+from launch_ros.descriptions import ParameterValue
 from launch.substitutions import Command
 from launch.actions import DeclareLaunchArgument, OpaqueFunction, GroupAction
 from launch.conditions import IfCondition, UnlessCondition
@@ -151,7 +151,7 @@ def generate_launch_description():
             package='robot_state_publisher',
             executable='robot_state_publisher',
             parameters=[{
-                'robot_description': launch_ros.descriptions.ParameterValue(
+                'robot_description': ParameterValue(
                     Command([
                         'xacro ', LaunchConfiguration('description_file'),
                         ' lidar:=', LaunchConfiguration('lidar'),
@@ -168,7 +168,7 @@ def generate_launch_description():
             executable='robot_state_publisher',
             namespace=LaunchConfiguration('namespace'),
             parameters=[{
-                'robot_description': launch_ros.descriptions.ParameterValue(
+                'robot_description': ParameterValue(
                     Command([
                         'xacro ', LaunchConfiguration('description_file'),
                         ' lidar:=', LaunchConfiguration('lidar'),

--- a/kobuki_description/launch/spawn.launch.py
+++ b/kobuki_description/launch/spawn.launch.py
@@ -18,7 +18,7 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -26,21 +26,34 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 def generate_launch_description():
 
+    # Initial robot pose
     declare_x_cmd = DeclareLaunchArgument('x', default_value='0.0')
     declare_y_cmd = DeclareLaunchArgument('y', default_value='0.0')
     declare_z_cmd = DeclareLaunchArgument('z', default_value='0.0')
     declare_roll_cmd = DeclareLaunchArgument('R', default_value='0.0')
     declare_pitch_cmd = DeclareLaunchArgument('P', default_value='0.0')
     declare_yaw_cmd = DeclareLaunchArgument('Y', default_value='0.0')
-    name_arg = DeclareLaunchArgument('name', default_value='kobuki')
-    gazebo_arg = DeclareLaunchArgument('gazebo', default_value='true')
-    camera_arg = DeclareLaunchArgument('camera', default_value='true')
-    lidar_arg = DeclareLaunchArgument('lidar', default_value='true')
+    lidar_arg = DeclareLaunchArgument(
+        'lidar',
+        default_value='true',
+        description='Enable lidar sensor'
+    )
+
+    camera_arg = DeclareLaunchArgument(
+        'camera',
+        default_value='true',
+        description='Enable camera sensor'
+    )
     use_sim_time_arg = DeclareLaunchArgument('use_sim_time', default_value='true')
+    name_arg = DeclareLaunchArgument(
+        'name',
+        default_value='kobuki',
+        description='Model name used in gazebo',
+    )
     namespace_arg = DeclareLaunchArgument(
         'namespace',
         default_value='',
-        description='Namespace to apply to the nodes'
+        description='Namespace to apply to the nodes, topics and TF frames'
     )
 
     robot_description = IncludeLaunchDescription(
@@ -50,7 +63,7 @@ def generate_launch_description():
         launch_arguments={
             'namespace': LaunchConfiguration('namespace'),
             'use_sim_time': LaunchConfiguration('use_sim_time'),
-            'gazebo': LaunchConfiguration('gazebo'),
+            'gazebo': 'true',
             'camera': LaunchConfiguration('camera'),
             'lidar': LaunchConfiguration('lidar'),
         }.items()
@@ -82,11 +95,10 @@ def generate_launch_description():
     ld.add_action(declare_roll_cmd)
     ld.add_action(declare_pitch_cmd)
     ld.add_action(declare_yaw_cmd)
-    ld.add_action(name_arg)
-    ld.add_action(gazebo_arg)
     ld.add_action(camera_arg)
     ld.add_action(lidar_arg)
     ld.add_action(use_sim_time_arg)
+    ld.add_action(name_arg)
     ld.add_action(namespace_arg)
     ld.add_action(robot_description)
     ld.add_action(gazebo_spawn_robot)

--- a/kobuki_description/urdf/kobuki.urdf.xacro
+++ b/kobuki_description/urdf/kobuki.urdf.xacro
@@ -9,6 +9,11 @@
   <xacro:arg name="lidar" default="false" />
   <xacro:arg name="camera" default="false" />
   <xacro:arg name="structure" default="false" />
+  <!-- Namespace will be applied to all TF frames and topics.
+       This is required if multiple robots are launched at the same time.
+       IMPORTANT: The namespace MUST include the trailing slash '/'.
+        This is required for compatibility with the base operation without namespace.
+  -->
   <xacro:arg name="namespace" default="" />
   <xacro:arg name="gazebo" default="false" />
 
@@ -19,21 +24,21 @@
   <xacro:if value="$(arg structure)">
     <xacro:include filename="$(find kobuki_description)/urdf/stacks/hexagons.urdf.xacro"/>
     <xacro:include filename="$(find kobuki_description)/urdf/stacks/circles.urdf.xacro"/>
-    <xacro:stack_hexagons parent="$(arg namespace)/base_link" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_1in number="0" parent="$(arg namespace)/base_link" x_loc="0.120" y_loc="0.082" z_loc="0.09" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_1in number="1" parent="$(arg namespace)/base_link" x_loc="0.055" y_loc="0.120" z_loc="0.09" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_1in number="2" parent="$(arg namespace)/base_link" x_loc="-0.055" y_loc="0.120" z_loc="0.09" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_1in number="3" parent="$(arg namespace)/base_link" x_loc="0.120" y_loc="-0.082" z_loc="0.09" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_1in number="4" parent="$(arg namespace)/base_link" x_loc="0.055" y_loc="-0.120" z_loc="0.09" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_1in number="5" parent="$(arg namespace)/base_link" x_loc="-0.055" y_loc="-0.120" z_loc="0.09" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_2in number="0" parent="$(arg namespace)/base_link" x_loc="0.0381" y_loc="0.1505" z_loc="0.1340" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_2in number="1" parent="$(arg namespace)/base_link" x_loc="0.0381" y_loc="-0.1505" z_loc="0.1340" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_2in number="2" parent="$(arg namespace)/base_link" x_loc="-0.0381" y_loc="0.1505" z_loc="0.1340" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_2in number="3" parent="$(arg namespace)/base_link" x_loc="-0.0381" y_loc="-0.1505" z_loc="0.1340" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_8in number="0" parent="$(arg namespace)/base_link" x_loc="0.0381" y_loc="0.1505" z_loc="0.1900" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_8in number="1" parent="$(arg namespace)/base_link" x_loc="0.0381" y_loc="-0.1505" z_loc="0.1900" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_8in number="2" parent="$(arg namespace)/base_link" x_loc="-0.0381" y_loc="0.1505" z_loc="0.1900" namespace="$(arg namespace)"/>
-    <xacro:turtlebot_standoff_8in number="3" parent="$(arg namespace)/base_link" x_loc="-0.0381" y_loc="-0.1505" z_loc="0.1900" namespace="$(arg namespace)"/>
+    <xacro:stack_hexagons parent="$(arg namespace)base_link" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_1in number="0" parent="$(arg namespace)base_link" x_loc="0.120" y_loc="0.082" z_loc="0.09" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_1in number="1" parent="$(arg namespace)base_link" x_loc="0.055" y_loc="0.120" z_loc="0.09" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_1in number="2" parent="$(arg namespace)base_link" x_loc="-0.055" y_loc="0.120" z_loc="0.09" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_1in number="3" parent="$(arg namespace)base_link" x_loc="0.120" y_loc="-0.082" z_loc="0.09" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_1in number="4" parent="$(arg namespace)base_link" x_loc="0.055" y_loc="-0.120" z_loc="0.09" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_1in number="5" parent="$(arg namespace)base_link" x_loc="-0.055" y_loc="-0.120" z_loc="0.09" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_2in number="0" parent="$(arg namespace)base_link" x_loc="0.0381" y_loc="0.1505" z_loc="0.1340" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_2in number="1" parent="$(arg namespace)base_link" x_loc="0.0381" y_loc="-0.1505" z_loc="0.1340" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_2in number="2" parent="$(arg namespace)base_link" x_loc="-0.0381" y_loc="0.1505" z_loc="0.1340" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_2in number="3" parent="$(arg namespace)base_link" x_loc="-0.0381" y_loc="-0.1505" z_loc="0.1340" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_8in number="0" parent="$(arg namespace)base_link" x_loc="0.0381" y_loc="0.1505" z_loc="0.1900" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_8in number="1" parent="$(arg namespace)base_link" x_loc="0.0381" y_loc="-0.1505" z_loc="0.1900" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_8in number="2" parent="$(arg namespace)base_link" x_loc="-0.0381" y_loc="0.1505" z_loc="0.1900" namespace="$(arg namespace)"/>
+    <xacro:turtlebot_standoff_8in number="3" parent="$(arg namespace)base_link" x_loc="-0.0381" y_loc="-0.1505" z_loc="0.1900" namespace="$(arg namespace)"/>
   </xacro:if>
 
   <xacro:if value="$(arg lidar)">
@@ -43,7 +48,7 @@
 
   <xacro:if value="$(arg camera)">
     <xacro:include filename="$(find kobuki_description)/urdf/sensors/asus_xtion_pro.urdf.xacro"/>
-    <xacro:sensor_asus_xtion_pro parent="$(arg namespace)/base_link" namespace="$(arg namespace)"/>
+    <xacro:sensor_asus_xtion_pro parent="$(arg namespace)base_link" namespace="$(arg namespace)"/>
   </xacro:if>
 
   <xacro:if value="$(arg gazebo)">

--- a/kobuki_description/urdf/kobuki_base.urdf.xacro
+++ b/kobuki_description/urdf/kobuki_base.urdf.xacro
@@ -11,7 +11,7 @@
 
   <!-- Kobuki -->
   <xacro:macro name="kobuki_base" params = "namespace">
-    <link name="$(arg namespace)/base_footprint"/>
+    <link name="$(arg namespace)base_footprint"/>
     <!--
        Base link is set at the bottom of the base mould.
        This is done to be compatible with the way base link
@@ -23,12 +23,12 @@
        axis, set the z-distance from the base_footprint
        to 0.352.
       -->
-    <joint name="$(arg namespace)/base_joint" type="fixed">
+    <joint name="$(arg namespace)base_joint" type="fixed">
       <origin xyz="0 0 0.0102" rpy="0 0 0" />
-      <parent link="$(arg namespace)/base_footprint"/>
-      <child link="$(arg namespace)/base_link" />
+      <parent link="$(arg namespace)base_footprint"/>
+      <child link="$(arg namespace)base_link" />
     </joint>
-    <link name="$(arg namespace)/base_link">
+    <link name="$(arg namespace)base_link">
       <visual>
         <geometry>
           <!-- new mesh -->
@@ -59,13 +59,13 @@
       </inertial>
     </link>
 
-    <joint name="$(arg namespace)/wheel_left_joint" type="continuous">
-      <parent link="$(arg namespace)/base_link"/>
-      <child link="$(arg namespace)/wheel_left_link"/>
+    <joint name="$(arg namespace)wheel_left_joint" type="continuous">
+      <parent link="$(arg namespace)base_link"/>
+      <child link="$(arg namespace)wheel_left_link"/>
       <origin xyz="0.00 ${0.23/2} 0.0250" rpy="${-M_PI/2} 0 0"/>
       <axis xyz="0 0 1"/>
     </joint>
-    <link name="$(arg namespace)/wheel_left_link">
+    <link name="$(arg namespace)wheel_left_link">
       <visual>
         <geometry>
           <mesh filename="file://$(find kobuki_description)/meshes/wheel.dae"/>
@@ -87,13 +87,13 @@
       </inertial>
     </link>
 
-    <joint name="$(arg namespace)/wheel_right_joint" type="continuous">
-      <parent link="$(arg namespace)/base_link"/>
-      <child link="$(arg namespace)/wheel_right_link"/>
+    <joint name="$(arg namespace)wheel_right_joint" type="continuous">
+      <parent link="$(arg namespace)base_link"/>
+      <child link="$(arg namespace)wheel_right_link"/>
       <origin xyz="0.00 -${0.23/2} 0.0250" rpy="${-M_PI/2} 0 0"/>
       <axis xyz="0 0 1"/>
     </joint>
-    <link name="$(arg namespace)/wheel_right_link">
+    <link name="$(arg namespace)wheel_right_link">
       <visual>
         <geometry>
           <mesh filename="file://$(find kobuki_description)/meshes/wheel.dae"/>
@@ -115,12 +115,12 @@
       </inertial>
     </link>
 
-    <joint name="$(arg namespace)/caster_front_joint" type="fixed">
-      <parent link="$(arg namespace)/base_link"/>
-      <child link="$(arg namespace)/caster_front_link"/>
+    <joint name="$(arg namespace)caster_front_joint" type="fixed">
+      <parent link="$(arg namespace)base_link"/>
+      <child link="$(arg namespace)caster_front_link"/>
       <origin xyz="0.115 0.0 0.007" rpy="${-M_PI/2} 0 0"/>
     </joint>
-    <link name="$(arg namespace)/caster_front_link">
+    <link name="$(arg namespace)caster_front_link">
       <collision>
         <geometry>
           <cylinder length="0.0176" radius="0.017"/>
@@ -136,12 +136,12 @@
       </inertial>
     </link>
 
-    <joint name="$(arg namespace)/caster_back_joint" type="fixed">
-      <parent link="$(arg namespace)/base_link"/>
-      <child link="$(arg namespace)/caster_back_link"/>
+    <joint name="$(arg namespace)caster_back_joint" type="fixed">
+      <parent link="$(arg namespace)base_link"/>
+      <child link="$(arg namespace)caster_back_link"/>
       <origin xyz="-0.135 0.0 0.009" rpy="${-M_PI/2} 0 0"/>
     </joint>
-    <link name="$(arg namespace)/caster_back_link">
+    <link name="$(arg namespace)caster_back_link">
       <collision>
         <geometry>
           <cylinder length="0.0176" radius="0.017"/>
@@ -158,13 +158,13 @@
     </link>
 
     <!-- Kobuki's sensors -->
-    <joint name="$(arg namespace)/gyro_joint" type="fixed">
+    <joint name="$(arg namespace)gyro_joint" type="fixed">
       <axis xyz="0 1 0"/>
       <origin xyz="0.056 0.062 0.0202" rpy="0 0 0"/>
-      <parent link="$(arg namespace)/base_link"/>
-      <child link="$(arg namespace)/gyro_link"/>
+      <parent link="$(arg namespace)base_link"/>
+      <child link="$(arg namespace)gyro_link"/>
     </joint>
-    <link name="$(arg namespace)/gyro_link">
+    <link name="$(arg namespace)gyro_link">
       <inertial>
         <mass value="0.001"/>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -174,12 +174,12 @@
       </inertial>
     </link>
 
-    <joint name="$(arg namespace)/cliff_sensor_left_joint" type="fixed">
+    <joint name="$(arg namespace)cliff_sensor_left_joint" type="fixed">
       <origin xyz="0.08734 0.13601 0.0214" rpy="0 ${M_PI/2} 0" />
-      <parent link="$(arg namespace)/base_link"/>
-      <child link="$(arg namespace)/cliff_sensor_left_link" />
+      <parent link="$(arg namespace)base_link"/>
+      <child link="$(arg namespace)cliff_sensor_left_link" />
     </joint>
-    <link name="$(arg namespace)/cliff_sensor_left_link">
+    <link name="$(arg namespace)cliff_sensor_left_link">
       <inertial>
         <mass value="0.0001" />
         <origin xyz="0 0 0" />
@@ -189,12 +189,12 @@
       </inertial>
     </link>
 
-    <joint name="$(arg namespace)/cliff_sensor_right_joint" type="fixed">
+    <joint name="$(arg namespace)cliff_sensor_right_joint" type="fixed">
       <origin xyz="0.085 -0.13601 0.0214" rpy="0 ${M_PI/2} 0" />
-      <parent link="$(arg namespace)/base_link"/>
-      <child link="$(arg namespace)/cliff_sensor_right_link" />
+      <parent link="$(arg namespace)base_link"/>
+      <child link="$(arg namespace)cliff_sensor_right_link" />
     </joint>
-    <link name="$(arg namespace)/cliff_sensor_right_link">
+    <link name="$(arg namespace)cliff_sensor_right_link">
       <inertial>
         <mass value="0.0001" />
         <origin xyz="0 0 0" />
@@ -204,12 +204,12 @@
       </inertial>
     </link>
 
-    <joint name="$(arg namespace)/cliff_sensor_front_joint" type="fixed">
+    <joint name="$(arg namespace)cliff_sensor_front_joint" type="fixed">
       <origin xyz="0.156 0.00 0.0214" rpy="0 ${M_PI/2} 0" />
-      <parent link="$(arg namespace)/base_link"/>
-      <child link="$(arg namespace)/cliff_sensor_front_link" />
+      <parent link="$(arg namespace)base_link"/>
+      <child link="$(arg namespace)cliff_sensor_front_link" />
     </joint>
-    <link name="$(arg namespace)/cliff_sensor_front_link">
+    <link name="$(arg namespace)cliff_sensor_front_link">
       <inertial>
         <mass value="0.0001" />
         <origin xyz="0 0 0" />

--- a/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
+++ b/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
@@ -5,23 +5,23 @@
 
     <gazebo>
       <plugin filename="gz-sim-diff-drive-system" name="gz::sim::systems::DiffDrive">
-        <left_joint>$(arg namespace)/wheel_left_joint</left_joint>
-        <right_joint>$(arg namespace)/wheel_right_joint</right_joint>
+        <left_joint>$(arg namespace)wheel_left_joint</left_joint>
+        <right_joint>$(arg namespace)wheel_right_joint</right_joint>
         <wheel_separation>0.223087</wheel_separation>
         <wheel_radius>0.035</wheel_radius>
         <max_linear_acceleration>1.0</max_linear_acceleration> 
-        <topic>$(arg namespace)/cmd_vel</topic>
-        <odom_topic>$(arg namespace)/odom</odom_topic>
-        <frame_id>$(arg namespace)/odom</frame_id>
-        <child_frame_id>$(arg namespace)/base_footprint</child_frame_id>
+        <topic>$(arg namespace)cmd_vel</topic>
+        <odom_topic>$(arg namespace)odom</odom_topic>
+        <frame_id>$(arg namespace)odom</frame_id>
+        <child_frame_id>$(arg namespace)base_footprint</child_frame_id>
         <odom_publisher_frequency>30</odom_publisher_frequency>
         <tf_topic>/tf</tf_topic>
       </plugin>
 
       <plugin filename="gz-sim-joint-state-publisher-system" name="gz::sim::systems::JointStatePublisher">
-        <topic>$(arg namespace)/joint_states</topic>
-        <joint>$(arg namespace)/wheel_left_joint</joint>
-        <joint>$(arg namespace)/wheel_right_joint</joint>
+        <topic>$(arg namespace)joint_states</topic>
+        <joint>$(arg namespace)wheel_left_joint</joint>
+        <joint>$(arg namespace)wheel_right_joint</joint>
       </plugin> 
     </gazebo>
 
@@ -31,13 +31,13 @@
       name="gz::sim::systems::Sensors">
       <render_engine>ogre2</render_engine>
     </plugin>
-      <gazebo reference="$(arg namespace)/laser_link">
-        <sensor name="$(arg namespace)/kobuki_lidar" type="gpu_lidar">
+      <gazebo reference="$(arg namespace)laser_link">
+        <sensor name="$(arg namespace)kobuki_lidar" type="gpu_lidar">
             <always_on>true</always_on>
             <visualize>true</visualize>
             <update_rate>5</update_rate>
-            <topic>$(arg namespace)/scan_raw</topic>
-            <gz_frame_id>$(arg namespace)/laser_link</gz_frame_id>
+            <topic>$(arg namespace)scan_raw</topic>
+            <gz_frame_id>$(arg namespace)laser_link</gz_frame_id>
             <lidar>
               <scan>
                 <horizontal>
@@ -63,12 +63,12 @@
     </xacro:if>
 
     <xacro:if value="$(arg camera)">
-      <gazebo reference="$(arg namespace)/camera_rgb_frame">
-        <sensor type="rgbd_camera" name="$(arg namespace)/kobuki_frame_sensor">
+      <gazebo reference="$(arg namespace)camera_rgb_frame">
+        <sensor type="rgbd_camera" name="$(arg namespace)kobuki_frame_sensor">
           <always_on>1</always_on>
           <update_rate>30.0</update_rate>
           <visualize>true</visualize>
-          <topic>$(arg namespace)/rgbd_camera</topic>
+          <topic>$(arg namespace)rgbd_camera</topic>
           <camera>
             <horizontal_fov>${63.0*M_PI/180.0}</horizontal_fov>
             <image>
@@ -87,7 +87,7 @@
               <p1>0.00000001</p1>
               <p2>0.00000001</p2>
             </distortion>
-            <optical_frame_id>$(arg namespace)/camera_rgb_optical_link</optical_frame_id>
+            <optical_frame_id>$(arg namespace)camera_rgb_optical_link</optical_frame_id>
           </camera>
         </sensor>
       </gazebo>

--- a/kobuki_description/urdf/sensors/astra.urdf.xacro
+++ b/kobuki_description/urdf/sensors/astra.urdf.xacro
@@ -10,28 +10,28 @@
   <xacro:property name="astra_dae_display_scale"   value="1" />
   <!-- Parameterised in part by the values in turtlebot_properties.urdf.xacro -->
   <xacro:macro name="sensor_astra" params="parent namespace">
-    <joint name="$(arg namespace)/camera_rgb_joint" type="fixed">
+    <joint name="$(arg namespace)camera_rgb_joint" type="fixed">
       <origin xyz="${cam_px} ${astra_cam_py} ${cam_pz}"
               rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/camera_rgb_frame" />
+      <child link="$(arg namespace)camera_rgb_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_rgb_frame"/>
+    <link name="$(arg namespace)camera_rgb_frame"/>
 
-    <joint name="$(arg namespace)/camera_rgb_optical_joint" type="fixed">
+    <joint name="$(arg namespace)camera_rgb_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="$(arg namespace)/camera_rgb_frame" />
-      <child link="$(arg namespace)/camera_rgb_optical_frame" />
+      <parent link="$(arg namespace)camera_rgb_frame" />
+      <child link="$(arg namespace)camera_rgb_optical_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_rgb_optical_frame"/>
+    <link name="$(arg namespace)camera_rgb_optical_frame"/>
 
-    <joint name="$(arg namespace)/camera_joint" type="fixed">
+    <joint name="$(arg namespace)camera_joint" type="fixed">
       <origin xyz="0 ${astra_cam_rel_rgb_py} 0"
               rpy="0 0 0"/>
-      <parent link="$(arg namespace)/camera_rgb_frame"/>
-      <child link="$(arg namespace)/camera_link"/>
+      <parent link="$(arg namespace)camera_rgb_frame"/>
+      <child link="$(arg namespace)camera_link"/>
     </joint>
-    <link name="$(arg namespace)/camera_link">
+    <link name="$(arg namespace)camera_link">
       <visual>
         <origin xyz="-0.04 0.02 -0.01" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
@@ -53,19 +53,19 @@
       </inertial>
     </link>
 
-    <joint name="$(arg namespace)/camera_depth_joint" type="fixed">
+    <joint name="$(arg namespace)camera_depth_joint" type="fixed">
       <origin xyz="0 ${astra_depth_rel_rgb_py} 0" rpy="0 0 0" />
-      <parent link="$(arg namespace)/camera_rgb_frame" />
-      <child link="$(arg namespace)/camera_depth_frame" />
+      <parent link="$(arg namespace)camera_rgb_frame" />
+      <child link="$(arg namespace)camera_depth_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_depth_frame"/>
+    <link name="$(arg namespace)camera_depth_frame"/>
 
-    <joint name="$(arg namespace)/camera_depth_optical_joint" type="fixed">
+    <joint name="$(arg namespace)camera_depth_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="$(arg namespace)/camera_depth_frame" />
-      <child link="$(arg namespace)/camera_depth_optical_frame" />
+      <parent link="$(arg namespace)camera_depth_frame" />
+      <child link="$(arg namespace)camera_depth_optical_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_depth_optical_frame"/>
+    <link name="$(arg namespace)camera_depth_optical_frame"/>
 
     <!-- RGBD sensor for simulation, same as Kinect -->
     <turtlebot_sim_3dsensor/>

--- a/kobuki_description/urdf/sensors/asus_xtion_pro.urdf.xacro
+++ b/kobuki_description/urdf/sensors/asus_xtion_pro.urdf.xacro
@@ -10,28 +10,28 @@
 
   <!-- Parameterised in part by the values in turtlebot_properties.urdf.xacro -->
   <xacro:macro name="sensor_asus_xtion_pro" params="parent namespace">
-    <joint name="$(arg namespace)/camera_rgb_joint" type="fixed">
+    <joint name="$(arg namespace)camera_rgb_joint" type="fixed">
       <origin xyz="${cam_px} ${asus_xtion_pro_cam_py} ${cam_pz}"
               rpy="${cam_or} ${cam_op} ${cam_oy}"/>
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/camera_rgb_frame" />
+      <child link="$(arg namespace)camera_rgb_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_rgb_frame"/>
+    <link name="$(arg namespace)camera_rgb_frame"/>
 
-    <joint name="$(arg namespace)/camera_rgb_optical_joint" type="fixed">
+    <joint name="$(arg namespace)camera_rgb_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0" />
-      <parent link="$(arg namespace)/camera_rgb_frame" />
-      <child link="$(arg namespace)/camera_rgb_optical_frame" />
+      <parent link="$(arg namespace)camera_rgb_frame" />
+      <child link="$(arg namespace)camera_rgb_optical_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_rgb_optical_frame"/>
+    <link name="$(arg namespace)camera_rgb_optical_frame"/>
 
-    <joint name="$(arg namespace)/camera_joint" type="fixed">
+    <joint name="$(arg namespace)camera_joint" type="fixed">
       <origin xyz="0 ${asus_xtion_pro_cam_rel_rgb_py} 0" 
               rpy="0 0 0"/>
-      <parent link="$(arg namespace)/camera_rgb_frame"/>
-      <child link="$(arg namespace)/camera_link"/>
+      <parent link="$(arg namespace)camera_rgb_frame"/>
+      <child link="$(arg namespace)camera_link"/>
     </joint>
-    <link name="$(arg namespace)/camera_link">
+    <link name="$(arg namespace)camera_link">
       <visual>
         <origin xyz="-0.015 0.0035 0.004" rpy="0 0 0"/>
         <geometry>
@@ -53,19 +53,19 @@
       </inertial>
     </link>
 
-    <joint name="$(arg namespace)/camera_depth_joint" type="fixed">
+    <joint name="$(arg namespace)camera_depth_joint" type="fixed">
       <origin xyz="0 ${asus_xtion_pro_depth_rel_rgb_py} 0" rpy="0 0 0" />
-      <parent link="$(arg namespace)/camera_rgb_frame" />
-      <child link="$(arg namespace)/camera_depth_frame" />
+      <parent link="$(arg namespace)camera_rgb_frame" />
+      <child link="$(arg namespace)camera_depth_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_depth_frame"/>
+    <link name="$(arg namespace)camera_depth_frame"/>
 
-    <joint name="$(arg namespace)/camera_depth_optical_joint" type="fixed">
+    <joint name="$(arg namespace)camera_depth_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0" />
-      <parent link="$(arg namespace)/camera_depth_frame" />
-      <child link="$(arg namespace)/camera_depth_optical_frame" />
+      <parent link="$(arg namespace)camera_depth_frame" />
+      <child link="$(arg namespace)camera_depth_optical_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_depth_optical_frame"/>
+    <link name="$(arg namespace)camera_depth_optical_frame"/>
 
   </xacro:macro>
 </robot>

--- a/kobuki_description/urdf/sensors/asus_xtion_pro_offset.urdf.xacro
+++ b/kobuki_description/urdf/sensors/asus_xtion_pro_offset.urdf.xacro
@@ -15,24 +15,24 @@
       <origin xyz="${cam_px} ${asus_xtion_pro_offset_cam_py} ${cam_pz}"
               rpy="${cam_or} ${cam_op} ${cam_oy}"/>
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/camera_rgb_frame" />
+      <child link="$(arg namespace)camera_rgb_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_rgb_frame"/>
+    <link name="$(arg namespace)camera_rgb_frame"/>
 
-    <joint name="$(arg namespace)/camera_rgb_optical_joint" type="fixed">
+    <joint name="$(arg namespace)camera_rgb_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="$(arg namespace)/camera_rgb_frame" />
-      <child link="$(arg namespace)/camera_rgb_optical_frame" />
+      <parent link="$(arg namespace)camera_rgb_frame" />
+      <child link="$(arg namespace)camera_rgb_optical_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_rgb_optical_frame"/>
+    <link name="$(arg namespace)camera_rgb_optical_frame"/>
 
-    <joint name="$(arg namespace)/camera_joint" type="fixed">
+    <joint name="$(arg namespace)camera_joint" type="fixed">
       <origin xyz="0 ${asus_xtion_pro_offset_cam_rel_rgb_py} 0" 
               rpy="0 0 0"/>
-      <parent link="$(arg namespace)/camera_rgb_frame"/>
-      <child link="$(arg namespace)/camera_link"/>
+      <parent link="$(arg namespace)camera_rgb_frame"/>
+      <child link="$(arg namespace)camera_link"/>
     </joint>
-    <link name="$(arg namespace)/camera_link">
+    <link name="$(arg namespace)camera_link">
       <visual>
         <origin xyz="-0.01 0 0" rpy="${-M_PI/2} -${M_PI} ${-M_PI/2}"/>
         <geometry>
@@ -54,19 +54,19 @@
       </inertial>
     </link>
 
-    <joint name="$(arg namespace)/camera_depth_joint" type="fixed">
+    <joint name="$(arg namespace)camera_depth_joint" type="fixed">
       <origin xyz="0 ${asus_xtion_pro_offset_depth_rel_rgb_py} 0" rpy="0 0 0" />
-      <parent link="$(arg namespace)/camera_rgb_frame" />
-      <child link="$(arg namespace)/camera_depth_frame" />
+      <parent link="$(arg namespace)camera_rgb_frame" />
+      <child link="$(arg namespace)camera_depth_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_depth_frame"/>
+    <link name="$(arg namespace)camera_depth_frame"/>
 
-    <joint name="$(arg namespace)/camera_depth_optical_joint" type="fixed">
+    <joint name="$(arg namespace)camera_depth_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="$(arg namespace)/camera_depth_frame" />
-      <child link="$(arg namespace)/camera_depth_optical_frame" />
+      <parent link="$(arg namespace)camera_depth_frame" />
+      <child link="$(arg namespace)camera_depth_optical_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_depth_optical_frame"/>
+    <link name="$(arg namespace)camera_depth_optical_frame"/>
 
     <!-- RGBD sensor for simulation, same as Kinect -->
     <turtlebot_sim_3dsensor/>

--- a/kobuki_description/urdf/sensors/kinect.urdf.xacro
+++ b/kobuki_description/urdf/sensors/kinect.urdf.xacro
@@ -6,26 +6,26 @@
   <xacro:property name="kinect_cam_py" value="-0.0125"/>
   <!-- Parameterised in part by the values in turtlebot_properties.urdf.xacro -->
   <xacro:macro name="sensor_kinect" params="parent namespace">
-    <joint name="c$(arg namespace)/amera_rgb_joint" type="fixed">
+    <joint name="c$(arg namespace)amera_rgb_joint" type="fixed">
       <origin xyz="${cam_px} ${kinect_cam_py} ${cam_pz}" rpy="${cam_or} ${cam_op} ${cam_oy}"/>
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/camera_rgb_frame" />
+      <child link="$(arg namespace)camera_rgb_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_rgb_frame"/>
+    <link name="$(arg namespace)camera_rgb_frame"/>
 
-    <joint name="$(arg namespace)/camera_rgb_optical_joint" type="fixed">
+    <joint name="$(arg namespace)camera_rgb_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="$(arg namespace)/camera_rgb_frame" />
-      <child link="$(arg namespace)/camera_rgb_optical_frame" />
+      <parent link="$(arg namespace)camera_rgb_frame" />
+      <child link="$(arg namespace)camera_rgb_optical_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_rgb_optical_frame"/>
+    <link name="$(arg namespace)camera_rgb_optical_frame"/>
 
-    <joint name="$(arg namespace)/camera_joint" type="fixed">
+    <joint name="$(arg namespace)camera_joint" type="fixed">
       <origin xyz="-0.031 ${-kinect_cam_py} -0.016" rpy="0 0 0"/>
-      <parent link="$(arg namespace)/camera_rgb_frame"/>
-      <child link="$(arg namespace)/camera_link"/>
+      <parent link="$(arg namespace)camera_rgb_frame"/>
+      <child link="$(arg namespace)camera_link"/>
     </joint>  
-      <link name="$(arg namespace)/camera_link">
+      <link name="$(arg namespace)camera_link">
       <visual>
        <origin xyz="0 0 0" rpy="0 0 ${M_PI/2}"/>
         <geometry>
@@ -50,19 +50,19 @@
     <!-- The fixed joints & links below are usually published by static_transformers launched by the OpenNi launch 
          files. However, for Gazebo simulation we need them, so we add them here.
          (Hence, don't publish them additionally!) -->
-	<joint name="$(arg namespace)/camera_depth_joint" type="fixed">
+	<joint name="$(arg namespace)camera_depth_joint" type="fixed">
 	  <origin xyz="0 ${2 * -kinect_cam_py} 0" rpy="0 0 0" />
-	  <parent link="$(arg namespace)/camera_rgb_frame" />
-	  <child link="$(arg namespace)/camera_depth_frame" />
+	  <parent link="$(arg namespace)camera_rgb_frame" />
+	  <child link="$(arg namespace)camera_depth_frame" />
 	</joint>
-	<link name="$(arg namespace)/camera_depth_frame"/>
+	<link name="$(arg namespace)camera_depth_frame"/>
 
-	<joint name="$(arg namespace)/camera_depth_optical_joint" type="fixed">
+	<joint name="$(arg namespace)camera_depth_optical_joint" type="fixed">
 	  <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-	  <parent link="$(arg namespace)/camera_depth_frame" />
-	  <child link="$(arg namespace)/camera_depth_optical_frame" />
+	  <parent link="$(arg namespace)camera_depth_frame" />
+	  <child link="$(arg namespace)camera_depth_optical_frame" />
 	</joint>
-	<link name="$(arg namespace)/camera_depth_optical_frame"/>
+	<link name="$(arg namespace)camera_depth_optical_frame"/>
 	
 	<!-- Kinect sensor for simulation -->
 	<turtlebot_sim_3dsensor/>

--- a/kobuki_description/urdf/sensors/lidar.urdf.xacro
+++ b/kobuki_description/urdf/sensors/lidar.urdf.xacro
@@ -3,7 +3,7 @@
 
   <xacro:macro name="sensor_lidar" params = "namespace">
   
-  <link name="$(arg namespace)/laser_link">
+  <link name="$(arg namespace)laser_link">
       <visual>
           <geometry>
             <mesh filename="file://$(find kobuki_description)/meshes/sensors/rplidar.dae" scale="0.001 0.001 0.001" /> 
@@ -19,10 +19,10 @@
         </inertial>
       </link>
 
-      <joint name="$(arg namespace)/laser_joint" type="fixed">
+      <joint name="$(arg namespace)laser_joint" type="fixed">
         <origin xyz="0.0 0.0 0.37" rpy="0 0 3.14" />
-        <parent link="$(arg namespace)/base_link"/>
-        <child link="$(arg namespace)/laser_link" />
+        <parent link="$(arg namespace)base_link"/>
+        <child link="$(arg namespace)laser_link" />
     </joint>
 
   </xacro:macro>

--- a/kobuki_description/urdf/sensors/r200.urdf.xacro
+++ b/kobuki_description/urdf/sensors/r200.urdf.xacro
@@ -38,12 +38,12 @@
     -->
     
     <!-- right bracket end -->
-    <joint name="$(arg namespace)/bracket_end_right_joint" type="fixed">
+    <joint name="$(arg namespace)bracket_end_right_joint" type="fixed">
       <origin xyz="${pole_px} ${pole_py} ${pole_pz}" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/bracket_end_right" />
+      <child link="$(arg namespace)bracket_end_right" />
     </joint>
-    <link name="$(arg namespace)/bracket_end_right">
+    <link name="$(arg namespace)bracket_end_right">
     <visual>
        <origin xyz="${-r200_bracket_end_width/2} ${r200_bracket_end_offset_py} ${r200_bracket_end_offset_pz}" rpy="0 0 ${-M_PI/2}"/>
         <geometry>
@@ -54,12 +54,12 @@
     </link>
  
     <!-- center main bracket -->
-    <joint name="$(arg namespace)/bracket_joint" type="fixed">
+    <joint name="$(arg namespace)bracket_joint" type="fixed">
       <origin xyz="${r200_bracket_width/2} ${r200_bracket_offset_py} ${r200_bracket_offset_pz}" rpy="0 0 0"/>
-      <parent link="$(arg namespace)/bracket_end_right"/>
-      <child link="$(arg namespace)/bracket" />
+      <parent link="$(arg namespace)bracket_end_right"/>
+      <child link="$(arg namespace)bracket" />
     </joint>
-    <link name="$(arg namespace)/bracket">
+    <link name="$(arg namespace)bracket">
     <visual>
        <origin xyz="0 0 0" rpy="0 0 ${M_PI/2}"/>
         <geometry>
@@ -70,12 +70,12 @@
     </link>
  
     <!-- left bracket end -->
-    <joint name="$(arg namespace)/bracket_end_left_joint" type="fixed">
+    <joint name="$(arg namespace)bracket_end_left_joint" type="fixed">
       <origin xyz="${-r200_bracket_width/2} ${r200_bracket_length - r200_bracket_offset_py} ${-r200_bracket_offset_pz}" rpy="0 0 0"/>
-      <parent link="$(arg namespace)/bracket"/>
-      <child link="$(arg namespace)/bracket_end_left" />
+      <parent link="$(arg namespace)bracket"/>
+      <child link="$(arg namespace)bracket_end_left" />
     </joint>
-    <link name="$(arg namespace)/bracket_end_left">
+    <link name="$(arg namespace)bracket_end_left">
     <visual>
        <origin xyz="${r200_bracket_end_width/2} 0 ${-r200_bracket_end_offset_pz}" rpy="0 0 ${M_PI/2}"/>
         <geometry>
@@ -86,12 +86,12 @@
     </link>
  
     <!-- camera body -->
-    <joint name="$(arg namespace)/camera_joint" type="fixed">
+    <joint name="$(arg namespace)camera_joint" type="fixed">
       <origin xyz="${r200_cam_offset_px} ${r200_cam_offset_py} ${r200_cam_offset_pz}" rpy="0 0 0"/>
-      <parent link="$(arg namespace)/bracket"/>
-      <child link="$(arg namespace)/camera_link" />
+      <parent link="$(arg namespace)bracket"/>
+      <child link="$(arg namespace)camera_link" />
     </joint>
-    <link name="$(arg namespace)/camera_link">
+    <link name="$(arg namespace)camera_link">
       <visual>
        <origin xyz="0 0 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
@@ -120,19 +120,19 @@
     ==  RGB joints & links ==
     -->
 
-    <joint name="$(arg namespace)/camera_rgb_joint" type="fixed">
+    <joint name="$(arg namespace)camera_rgb_joint" type="fixed">
       <origin xyz="${r200_cam_rgb_px} ${r200_cam_rgb_py} ${r200_cam_rgb_pz}" rpy="0 0 0"/>
-      <parent link="$(arg namespace)/camera_link"/>
-      <child link="$(arg namespace)/camera_rgb_frame" />
+      <parent link="$(arg namespace)camera_link"/>
+      <child link="$(arg namespace)camera_rgb_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_rgb_frame"/>
+    <link name="$(arg namespace)camera_rgb_frame"/>
 
-    <joint name="$(arg namespace)/camera_rgb_optical_joint" type="fixed">
+    <joint name="$(arg namespace)camera_rgb_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-      <parent link="$(arg namespace)/camera_rgb_frame" />
-      <child link="$(arg namespace)/camera_rgb_optical_frame" />
+      <parent link="$(arg namespace)camera_rgb_frame" />
+      <child link="$(arg namespace)camera_rgb_optical_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_rgb_optical_frame"/>
+    <link name="$(arg namespace)camera_rgb_optical_frame"/>
     
   
 
@@ -140,19 +140,19 @@
     ==  Depth joints & links ==
     -->
 
-    <joint name="$(arg namespace)/camera_depth_joint" type="fixed">
+    <joint name="$(arg namespace)camera_depth_joint" type="fixed">
         <origin xyz="0 ${r200_cam_depth_offset} 0" rpy="0 0 0" />
-        <parent link="$(arg namespace)/camera_rgb_frame" />
-        <child link="$(arg namespace)/camera_depth_frame" />
+        <parent link="$(arg namespace)camera_rgb_frame" />
+        <child link="$(arg namespace)camera_depth_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_depth_frame"/>
+    <link name="$(arg namespace)camera_depth_frame"/>
 
-    <joint name="$(arg namespace)/camera_depth_optical_joint" type="fixed">
+    <joint name="$(arg namespace)camera_depth_optical_joint" type="fixed">
         <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
-        <parent link="$(arg namespace)/camera_depth_frame" />
-        <child link="$(arg namespace)/camera_depth_optical_frame" />
+        <parent link="$(arg namespace)camera_depth_frame" />
+        <child link="$(arg namespace)camera_depth_optical_frame" />
     </joint>
-    <link name="$(arg namespace)/camera_depth_optical_frame"/>
+    <link name="$(arg namespace)camera_depth_optical_frame"/>
     
   	
   	<!-- Simulation sensor -->

--- a/kobuki_description/urdf/stacks/circles.urdf.xacro
+++ b/kobuki_description/urdf/stacks/circles.urdf.xacro
@@ -2,13 +2,13 @@
 <robot name="turtlebot_hardware" xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="turtlebot_spacer" params="parent number x_loc y_loc z_loc namespace">
-    <joint name="$(arg namespace)/spacer_${number}_joint" type="fixed">
+    <joint name="$(arg namespace)spacer_${number}_joint" type="fixed">
       <origin xyz="${x_loc} ${y_loc} ${z_loc}" rpy="0 0 0" />
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/spacer_${number}_link" />
+      <child link="$(arg namespace)spacer_${number}_link" />
     </joint>
 
-    <link name="$(arg namespace)/spacer_${number}_link">
+    <link name="$(arg namespace)spacer_${number}_link">
       <inertial>
         <mass value="0.001" />
         <origin xyz="0 0 0" />
@@ -34,13 +34,13 @@
   </xacro:macro>
 
   <xacro:macro name="turtlebot_standoff_1in" params="parent number x_loc y_loc z_loc namespace">
-    <joint name="$(arg namespace)/standoff_1in_${number}_joint" type="fixed">
+    <joint name="$(arg namespace)standoff_1in_${number}_joint" type="fixed">
       <origin xyz="${x_loc} ${y_loc} ${z_loc}" rpy="0 0 0" />
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/standoff_1in_${number}_link" />
+      <child link="$(arg namespace)standoff_1in_${number}_link" />
     </joint>
 
-    <link name="$(arg namespace)/standoff_1in_${number}_link">
+    <link name="$(arg namespace)standoff_1in_${number}_link">
       <inertial>
         <mass value="0.001" />
         <origin xyz="0 0 0" />
@@ -66,13 +66,13 @@
   </xacro:macro>
 
   <xacro:macro name="turtlebot_standoff_2in" params="parent number x_loc y_loc z_loc namespace">
-    <joint name="$(arg namespace)/standoff_2in_${number}_joint" type="fixed">
+    <joint name="$(arg namespace)standoff_2in_${number}_joint" type="fixed">
       <origin xyz="${x_loc} ${y_loc} ${z_loc}" rpy="0 0 0" />
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/standoff_2in_${number}_link" />
+      <child link="$(arg namespace)standoff_2in_${number}_link" />
     </joint>
 
-    <link name="$(arg namespace)/standoff_2in_${number}_link">
+    <link name="$(arg namespace)standoff_2in_${number}_link">
       <inertial>
         <mass value="0.001" />
         <origin xyz="0 0 0" />
@@ -99,13 +99,13 @@
 
 
   <xacro:macro name="turtlebot_standoff_8in" params="parent number x_loc y_loc z_loc namespace">
-    <joint name="$(arg namespace)/standoff_8in_${number}_joint" type="fixed">
+    <joint name="$(arg namespace)standoff_8in_${number}_joint" type="fixed">
       <origin xyz="${x_loc} ${y_loc} ${z_loc}" rpy="0 0 0" />
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/standoff_8in_${number}_link" />
+      <child link="$(arg namespace)standoff_8in_${number}_link" />
     </joint>
 
-    <link name="$(arg namespace)/standoff_8in_${number}_link">
+    <link name="$(arg namespace)standoff_8in_${number}_link">
       <inertial>
         <mass value="0.001" />
         <origin xyz="0 0 0" />
@@ -131,13 +131,13 @@
   </xacro:macro>
 
   <xacro:macro name="turtlebot_standoff_kinect" params="parent number x_loc y_loc z_loc namespace">
-    <joint name="$(arg namespace)/standoff_kinect_${number}_joint" type="fixed">
+    <joint name="$(arg namespace)standoff_kinect_${number}_joint" type="fixed">
       <origin xyz="${x_loc} ${y_loc} ${z_loc}" rpy="0 0 0" />
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/standoff_kinect_${number}_link" />
+      <child link="$(arg namespace)standoff_kinect_${number}_link" />
     </joint>
 
-    <link name="$(arg namespace)/standoff_kinect_${number}_link">
+    <link name="$(arg namespace)standoff_kinect_${number}_link">
       <inertial>
         <mass value="0.001" />
         <origin xyz="0 0 0" />
@@ -168,14 +168,14 @@
     <turtlebot_spacer parent="${parent}" number="2" x_loc="-0.07239" y_loc="-0.1114679" z_loc="0.062992"/>
     <turtlebot_spacer parent="${parent}" number="3" x_loc="-0.07239" y_loc="0.1114679" z_loc="0.062992"/>
 
-    <joint name="$(arg namespace)/plate_0_joint" type="fixed">
+    <joint name="$(arg namespace)plate_0_joint" type="fixed">
       <origin xyz="-0.04334 0  0.06775704" rpy="0 0 0" />
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/plate_0_link" />
+      <child link="$(arg namespace)plate_0_link" />
     </joint>
 
 
-    <link name="$(arg namespace)/plate_0_link">
+    <link name="$(arg namespace)plate_0_link">
       <inertial>
         <mass value="0.01" />
         <origin xyz="0 0 0" />
@@ -204,13 +204,13 @@
     <turtlebot_standoff_2in parent="${parent}" number="2" x_loc="-0.052832" y_loc="-0.1314196" z_loc="0.0709803"/>
     <turtlebot_standoff_2in parent="${parent}" number="3" x_loc="-0.052832" y_loc="0.1314196" z_loc="0.0709803"/>
 
-    <joint name="$(arg namespace)/plate_1_joint" type="fixed">
+    <joint name="$(arg namespace)plate_1_joint" type="fixed">
       <origin xyz="0.04068 0 0.05715" rpy="0 0 0" />
-      <parent link="$(arg namespace)/plate_0_link"/>
-      <child link="$(arg namespace)/plate_1_link" />
+      <parent link="$(arg namespace)plate_0_link"/>
+      <child link="$(arg namespace)plate_1_link" />
     </joint>
 
-    <link name="$(arg namespace)/plate_1_link">
+    <link name="$(arg namespace)plate_1_link">
       <inertial>
         <mass value="0.1" />
         <origin xyz="0 0 0" />

--- a/kobuki_description/urdf/stacks/hexagons.urdf.xacro
+++ b/kobuki_description/urdf/stacks/hexagons.urdf.xacro
@@ -11,12 +11,12 @@
   <!-- Xacro macros -->
   <!-- Pole macros -->
   <xacro:macro name="stack_bottom_pole" params="parent number x_loc y_loc z_loc namespace">
-    <joint name="$(arg namespace)/pole_bottom_${number}_joint" type="fixed">
+    <joint name="$(arg namespace)pole_bottom_${number}_joint" type="fixed">
       <origin xyz="${x_loc} ${y_loc} ${z_loc}" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/pole_bottom_${number}_link"/>
+      <child link="$(arg namespace)pole_bottom_${number}_link"/>
     </joint>
-    <link name="$(arg namespace)/pole_bottom_${number}_link">
+    <link name="$(arg namespace)pole_bottom_${number}_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -40,12 +40,12 @@
   </xacro:macro>
   
   <xacro:macro name="stack_middle_pole" params="parent number x_loc y_loc z_loc namespace">  
-    <joint name="$(arg namespace)/pole_middle_${number}_joint" type="fixed">
+    <joint name="$(arg namespace)pole_middle_${number}_joint" type="fixed">
       <origin xyz="${x_loc} ${y_loc} ${z_loc}" rpy="0 0 0" />
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/pole_middle_${number}_link"/>
+      <child link="$(arg namespace)pole_middle_${number}_link"/>
     </joint>
-    <link name="$(arg namespace)/pole_middle_${number}_link">
+    <link name="$(arg namespace)pole_middle_${number}_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 ${M_PI} 0"/>
         <geometry>
@@ -69,12 +69,12 @@
   </xacro:macro>
 
   <xacro:macro name="stack_top_pole" params="parent number x_loc y_loc z_loc namespace ">  
-    <joint name="$(arg namespace)/pole_top_${number}_joint" type="fixed">
+    <joint name="$(arg namespace)pole_top_${number}_joint" type="fixed">
       <origin xyz="${x_loc} ${y_loc} ${z_loc}" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/pole_top_${number}_link"/>
+      <child link="$(arg namespace)pole_top_${number}_link"/>
     </joint>
-    <link name="$(arg namespace)/pole_top_${number}_link">
+    <link name="$(arg namespace)pole_top_${number}_link">
       <visual>
         <origin xyz=" 0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -98,12 +98,12 @@
   </xacro:macro>
 
   <xacro:macro name="stack_3d_sensor_pole" params="parent number x_loc y_loc z_loc namespace ">
-    <joint name="$(arg namespace)/pole_kinect_${number}_joint" type="fixed">
+    <joint name="$(arg namespace)pole_kinect_${number}_joint" type="fixed">
       <origin xyz="${x_loc} ${y_loc} ${z_loc}" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/pole_kinect_${number}_link"/>
+      <child link="$(arg namespace)pole_kinect_${number}_link"/>
     </joint>
-    <link name="$(arg namespace)/pole_kinect_${number}_link">
+    <link name="$(arg namespace)pole_kinect_${number}_link">
       <visual>
         <origin xyz="0 0 -0.01" rpy="0 0 0"/>
         <geometry>
@@ -139,12 +139,12 @@
     <stack_bottom_pole parent="${parent}" number="4" x_loc= "0.055" y_loc="-0.120" z_loc="0.1028"/>
     <stack_bottom_pole parent="${parent}" number="5" x_loc="-0.055" y_loc="-0.120" z_loc="0.1028"/>
     
-    <joint name="$(arg namespace)/plate_bottom_joint" type="fixed">
+    <joint name="$(arg namespace)plate_bottom_joint" type="fixed">
       <origin xyz="0.02364 0.0 0.1306" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/plate_bottom_link"/>
+      <child link="$(arg namespace)plate_bottom_link"/>
     </joint>  
-    <link name="$(arg namespace)/plate_bottom_link">
+    <link name="$(arg namespace)plate_bottom_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -171,12 +171,12 @@
     <stack_middle_pole parent="${parent}" number="2" x_loc="-0.0381" y_loc= "0.1505" z_loc="0.1640"/>
     <stack_middle_pole parent="${parent}" number="3" x_loc="-0.0381" y_loc="-0.1505" z_loc="0.1640"/>
     
-    <joint name="$(arg namespace)/plate_middle_joint" type="fixed">
+    <joint name="$(arg namespace)plate_middle_joint" type="fixed">
       <origin xyz="-0.01364 0.0 0.1874" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/plate_middle_link"/>
+      <child link="$(arg namespace)plate_middle_link"/>
     </joint>  
-    <link name="$(arg namespace)/plate_middle_link">
+    <link name="$(arg namespace)plate_middle_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -205,12 +205,12 @@
     <stack_3d_sensor_pole parent="${parent}" number="0" x_loc="-0.1024" y_loc= "0.098" z_loc="0.2372"/>
     <stack_3d_sensor_pole parent="${parent}" number="1" x_loc="-0.1024" y_loc="-0.098" z_loc="0.2372"/>
     
-    <joint name="$(arg namespace)/plate_top_joint" type="fixed">
+    <joint name="$(arg namespace)plate_top_joint" type="fixed">
       <origin xyz="-0.01364 0.0  0.3966" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="$(arg namespace)/plate_top_link"/>
+      <child link="$(arg namespace)plate_top_link"/>
     </joint>  
-    <link name="$(arg namespace)/plate_top_link">
+    <link name="$(arg namespace)plate_top_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>


### PR DESCRIPTION
I detected some issues in the multirobot branch when using an empty namespace. TF frames were keeping an initial slash '/', which caused errors.

This PR fixes that and makes possible to use the same launch files for single and multi-robot with and without namespaces. I also added some comments in the main URDF file to clarify the format of the namespace and made the launch arguments a bit more clear.