### PR TITLE
Support for namespaces in the tf topics

### DIFF
--- a/kobuki_description/config/bridge/kobuki_bridge.yaml
+++ b/kobuki_description/config/bridge/kobuki_bridge.yaml
@@ -4,8 +4,8 @@
   gz_type_name: "gz.msgs.Twist"
   direction: ROS_TO_GZ
 
-- ros_topic_name: "/tf"
-  gz_topic_name: "/tf"
+- ros_topic_name: "<tf_namespace>/tf"
+  gz_topic_name: "<tf_namespace>/tf"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
@@ -34,8 +34,8 @@
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "<robot_namespace>/rgbd_camera/points"
-  gz_topic_name: "<robot_namespace>/rgbd_camera/points"
-  ros_type_name: "sensor_msgs/msg/PointCloud2"
-  gz_type_name: "gz.msgs.PointCloudPacked"
-  direction: GZ_TO_ROS
+# - ros_topic_name: "<robot_namespace>/rgbd_camera/points"
+#   gz_topic_name: "<robot_namespace>/rgbd_camera/points"
+#   ros_type_name: "sensor_msgs/msg/PointCloud2"
+#   gz_type_name: "gz.msgs.PointCloudPacked"
+#   direction: GZ_TO_ROS

--- a/kobuki_description/config/bridge/kobuki_bridge.yaml
+++ b/kobuki_description/config/bridge/kobuki_bridge.yaml
@@ -34,8 +34,8 @@
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS
 
-# - ros_topic_name: "<robot_namespace>/rgbd_camera/points"
-#   gz_topic_name: "<robot_namespace>/rgbd_camera/points"
-#   ros_type_name: "sensor_msgs/msg/PointCloud2"
-#   gz_type_name: "gz.msgs.PointCloudPacked"
-#   direction: GZ_TO_ROS
+- ros_topic_name: "<robot_namespace>/rgbd_camera/points"
+  gz_topic_name: "<robot_namespace>/rgbd_camera/points"
+  ros_type_name: "sensor_msgs/msg/PointCloud2"
+  gz_type_name: "gz.msgs.PointCloudPacked"
+  direction: GZ_TO_ROS

--- a/kobuki_description/launch/spawn.launch.py
+++ b/kobuki_description/launch/spawn.launch.py
@@ -55,6 +55,11 @@ def generate_launch_description():
         default_value='',
         description='Namespace to apply to the nodes, topics and TF frames'
     )
+    declare_do_tf_remapping_arg = DeclareLaunchArgument(
+        'do_tf_remapping',
+        default_value='False',
+        description='Whether to remap the tf topic to independent namespaces (/tf -> tf)',
+    )
 
     robot_description = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([os.path.join(
@@ -63,6 +68,7 @@ def generate_launch_description():
         launch_arguments={
             'namespace': LaunchConfiguration('namespace'),
             'use_sim_time': LaunchConfiguration('use_sim_time'),
+            'do_tf_remapping': LaunchConfiguration('do_tf_remapping'),
             'gazebo': 'true',
             'camera': LaunchConfiguration('camera'),
             'lidar': LaunchConfiguration('lidar'),
@@ -100,6 +106,7 @@ def generate_launch_description():
     ld.add_action(use_sim_time_arg)
     ld.add_action(name_arg)
     ld.add_action(namespace_arg)
+    ld.add_action(declare_do_tf_remapping_arg)
     ld.add_action(robot_description)
     ld.add_action(gazebo_spawn_robot)
 

--- a/kobuki_description/urdf/kobuki.urdf.xacro
+++ b/kobuki_description/urdf/kobuki.urdf.xacro
@@ -15,6 +15,12 @@
         This is required for compatibility with the base operation without namespace.
   -->
   <xacro:arg name="namespace" default="" />
+  <!-- The tf namespace is independent from the regular namespace.
+       This namespace is only applied to the /tf topic.
+       This allows having multiple robots with namespaces either sharing a common /tf topic
+       or with independent /<namespace>/tf topics.
+  -->
+  <xacro:arg name="tf_namespace" default="" />
   <xacro:arg name="gazebo" default="false" />
 
   <xacro:include filename="$(find kobuki_description)/urdf/kobuki_base.urdf.xacro" />
@@ -53,7 +59,7 @@
 
   <xacro:if value="$(arg gazebo)">
     <xacro:include filename="$(find kobuki_description)/urdf/kobuki_gazebo.urdf.xacro"/>
-    <xacro:kobuki_gazebo lidar="$(arg lidar)" camera="$(arg camera)" namespace="$(arg namespace)"/>
+    <xacro:kobuki_gazebo lidar="$(arg lidar)" camera="$(arg camera)" namespace="$(arg namespace)" tf_namespace="$(arg tf_namespace)"/>
   </xacro:if>
   
 </robot>

--- a/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
+++ b/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <robot name="kobuki_gazebo" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="kobuki_gazebo" params="lidar camera namespace">
+  <xacro:macro name="kobuki_gazebo" params="lidar camera namespace tf_namespace">
 
     <gazebo>
       <plugin filename="gz-sim-diff-drive-system" name="gz::sim::systems::DiffDrive">
@@ -15,7 +15,7 @@
         <frame_id>$(arg namespace)odom</frame_id>
         <child_frame_id>$(arg namespace)base_footprint</child_frame_id>
         <odom_publisher_frequency>30</odom_publisher_frequency>
-        <tf_topic>/tf</tf_topic>
+        <tf_topic>$(arg tf_namespace)tf</tf_topic>
       </plugin>
 
       <plugin filename="gz-sim-joint-state-publisher-system" name="gz::sim::systems::JointStatePublisher">


### PR DESCRIPTION
This PR allows enabling/disabling the namespace in the tf topic with the argument `do_tf_remapping`.

* By default (false), a common `/tf` is used for all frames and all robots.
* If set to `true`, it will create a different namespace for each robot: `/r1/tf`, `/r2/tf`, etc. This behaviour is similar to what nav2 does.

Note that if a namespace is used with a robot, all tf frames will be prefixed with the namespace (e.g. `r1/base_link`), regardless of the namespace in the tf topic.