### PR TITLE
Update lidar joint rotation to 180 degrees

### DIFF
--- a/kobuki_description/launch/kobuki_description.launch.py
+++ b/kobuki_description/launch/kobuki_description.launch.py
@@ -145,6 +145,30 @@ def generate_launch_description():
         'lidar', default_value='false',
         description='Enable lidar sensor')
 
+    lidar_position_x_arg = DeclareLaunchArgument(
+        'lidar_position_x', default_value='0',
+        description='Lidar X position relative to base_link')
+
+    lidar_position_y_arg = DeclareLaunchArgument(
+        'lidar_position_y', default_value='0',
+        description='Lidar Y position relative to base_link')
+
+    lidar_position_z_arg = DeclareLaunchArgument(
+        'lidar_position_z', default_value='0.37',
+        description='Lidar Z position relative to base_link')
+
+    lidar_orientation_roll_arg = DeclareLaunchArgument(
+        'lidar_orientation_roll', default_value='0',
+        description='Lidar roll orientation')
+
+    lidar_orientation_pitch_arg = DeclareLaunchArgument(
+        'lidar_orientation_pitch', default_value='0',
+        description='Lidar pitch orientation')
+
+    lidar_orientation_yaw_arg = DeclareLaunchArgument(
+        'lidar_orientation_yaw', default_value='0',
+        description='Lidar yaw orientation')
+
     camera_arg = DeclareLaunchArgument(
         'camera', default_value='false',
         description='Enable camera sensor')
@@ -198,6 +222,15 @@ def generate_launch_description():
                     Command([
                         'xacro ', LaunchConfiguration('description_file'),
                         ' lidar:=', LaunchConfiguration('lidar'),
+                        ' lidar_position_x:=', LaunchConfiguration('lidar_position_x'),
+                        ' lidar_position_y:=', LaunchConfiguration('lidar_position_y'),
+                        ' lidar_position_z:=', LaunchConfiguration('lidar_position_z'),
+                        ' lidar_orientation_roll:=',
+                        LaunchConfiguration('lidar_orientation_roll'),
+                        ' lidar_orientation_pitch:=',
+                        LaunchConfiguration('lidar_orientation_pitch'),
+                        ' lidar_orientation_yaw:=',
+                        LaunchConfiguration('lidar_orientation_yaw'),
                         ' camera:=', LaunchConfiguration('camera'),
                         ' structure:=', LaunchConfiguration('structure'),
                         ' gazebo:=', LaunchConfiguration('gazebo')
@@ -215,6 +248,15 @@ def generate_launch_description():
                     Command([
                         'xacro ', LaunchConfiguration('description_file'),
                         ' lidar:=', LaunchConfiguration('lidar'),
+                        ' lidar_position_x:=', LaunchConfiguration('lidar_position_x'),
+                        ' lidar_position_y:=', LaunchConfiguration('lidar_position_y'),
+                        ' lidar_position_z:=', LaunchConfiguration('lidar_position_z'),
+                        ' lidar_orientation_roll:=',
+                        LaunchConfiguration('lidar_orientation_roll'),
+                        ' lidar_orientation_pitch:=',
+                        LaunchConfiguration('lidar_orientation_pitch'),
+                        ' lidar_orientation_yaw:=',
+                        LaunchConfiguration('lidar_orientation_yaw'),
                         ' camera:=', LaunchConfiguration('camera'),
                         ' structure:=', LaunchConfiguration('structure'),
                         # Must append the trailing slash when a namespace is active
@@ -239,6 +281,12 @@ def generate_launch_description():
 
     ld = LaunchDescription()
     ld.add_action(lidar_arg)
+    ld.add_action(lidar_position_x_arg)
+    ld.add_action(lidar_position_y_arg)
+    ld.add_action(lidar_position_z_arg)
+    ld.add_action(lidar_orientation_roll_arg)
+    ld.add_action(lidar_orientation_pitch_arg)
+    ld.add_action(lidar_orientation_yaw_arg)
     ld.add_action(camera_arg)
     ld.add_action(structure_arg)
     ld.add_action(gazebo_arg)

--- a/kobuki_description/urdf/kobuki.urdf.xacro
+++ b/kobuki_description/urdf/kobuki.urdf.xacro
@@ -7,6 +7,12 @@
 <robot name="kobuki" xmlns:xacro="http://ros.org/wiki/xacro" >
 
   <xacro:arg name="lidar" default="false" />
+  <xacro:arg name="lidar_position_x" default="0" />
+  <xacro:arg name="lidar_position_y" default="0" />
+  <xacro:arg name="lidar_position_z" default="0.37" />
+  <xacro:arg name="lidar_orientation_roll" default="0" />
+  <xacro:arg name="lidar_orientation_pitch" default="0" />
+  <xacro:arg name="lidar_orientation_yaw" default="0" />
   <xacro:arg name="camera" default="false" />
   <xacro:arg name="structure" default="false" />
   <!-- Namespace will be applied to all TF frames and topics.
@@ -49,7 +55,13 @@
 
   <xacro:if value="$(arg lidar)">
     <xacro:include filename="$(find kobuki_description)/urdf/sensors/lidar.urdf.xacro"/>
-    <xacro:sensor_lidar namespace="$(arg namespace)"/>
+    <xacro:sensor_lidar namespace="$(arg namespace)" 
+                        x="$(arg lidar_position_x)" 
+                        y="$(arg lidar_position_y)" 
+                        z="$(arg lidar_position_z)"
+                        roll="$(arg lidar_orientation_roll)" 
+                        pitch="$(arg lidar_orientation_pitch)" 
+                        yaw="$(arg lidar_orientation_yaw)"/>
   </xacro:if>
 
   <xacro:if value="$(arg camera)">

--- a/kobuki_description/urdf/sensors/lidar.urdf.xacro
+++ b/kobuki_description/urdf/sensors/lidar.urdf.xacro
@@ -20,7 +20,7 @@
       </link>
 
       <joint name="$(arg namespace)laser_joint" type="fixed">
-        <origin xyz="0.0 0.0 0.37" rpy="0 0 0" />
+        <origin xyz="0.0 0.0 0.37" rpy="3.1416 0 0" />
         <parent link="$(arg namespace)base_link"/>
         <child link="$(arg namespace)laser_link" />
     </joint>

--- a/kobuki_description/urdf/sensors/lidar.urdf.xacro
+++ b/kobuki_description/urdf/sensors/lidar.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot name="sensor_lidar" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="sensor_lidar" params = "namespace">
+  <xacro:macro name="sensor_lidar" params = "namespace x:=0 y:=0 z:=0.37 roll:=0 pitch:=0 yaw:=0">
   
   <link name="$(arg namespace)laser_link">
       <visual>
@@ -20,7 +20,7 @@
       </link>
 
       <joint name="$(arg namespace)laser_joint" type="fixed">
-        <origin xyz="0.0 0.0 0.37" rpy="3.1416 0 0" />
+        <origin xyz="${x} ${y} ${z}" rpy="${roll} ${pitch} ${yaw}" />
         <parent link="$(arg namespace)base_link"/>
         <child link="$(arg namespace)laser_link" />
     </joint>


### PR DESCRIPTION
Hi @Juancams,

I was chatting with @rodperex and we both think that the TF for the laser should match the current LiDAR setup, which is mounted on the Kobuki’s ceiling (flipped).

Let me know if you agree with this approach or if you prefer, we could add a xacro argument to keep things more flexible.