### PR TITLE
Fix: Update camera frame_id to optical_frame

### DIFF
--- a/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
+++ b/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
@@ -62,13 +62,14 @@
       </gazebo>
     </xacro:if>
 
-    <xacro:if value="$(arg camera)">
+<xacro:if value="$(arg camera)">
       <gazebo reference="$(arg namespace)camera_rgb_frame">
         <sensor type="rgbd_camera" name="$(arg namespace)kobuki_frame_sensor">
           <always_on>1</always_on>
           <update_rate>30.0</update_rate>
           <visualize>true</visualize>
           <topic>$(arg namespace)rgbd_camera</topic>
+          <gz_frame_id>$(arg namespace)camera_rgb_optical_frame</gz_frame_id>
           <camera>
             <horizontal_fov>${63.0*M_PI/180.0}</horizontal_fov>
             <image>
@@ -87,7 +88,7 @@
               <p1>0.00000001</p1>
               <p2>0.00000001</p2>
             </distortion>
-            <optical_frame_id>$(arg namespace)camera_link</optical_frame_id>
+            <optical_frame_id>$(arg namespace)camera_rgb_optical_frame</optical_frame_id>
           </camera>
         </sensor>
       </gazebo>

--- a/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
+++ b/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
@@ -62,7 +62,7 @@
       </gazebo>
     </xacro:if>
 
-<xacro:if value="$(arg camera)">
+    <xacro:if value="$(arg camera)">
       <gazebo reference="$(arg namespace)camera_rgb_frame">
         <sensor type="rgbd_camera" name="$(arg namespace)kobuki_frame_sensor">
           <always_on>1</always_on>


### PR DESCRIPTION
This PR updates the camera's frame_id to use the correct optical frame. This ensures the coordinate system is properly aligned for image processing tasks, adhering to standard ROS conventions (Z-forward for optical frames).

Changes:
- Added `gz_frame_id` set to `camera_rgb_optical_frame`.
- Switched the active camera frame from `camera_link` to `optical_frame`.

Known Issues / WIP:
- PointCloud Rotation: Please note that the `PointCloud` still has an incorrect rotation relative to the base frame. This PR strictly fixes the 2D image frame; the 3D rotation issue remains and will be addressed in a separate update.